### PR TITLE
Add capture mode for interactive mock creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,147 @@
 # simple-mock-server
-Local server to mock API calls to an external service.
 
-# Installation
-## Env variables
-Set SIMPLE_MOCKS_LOCATION environment variable with the directory of your json files or use the -d flag.
+A local HTTP mock server with an interactive terminal UI. Define mock responses as JSON files, manage them live from the TUI, and capture real requests to create new mocks on the fly.
 
-REMEMBER TO USE THE .json EXTENSION in each mock!
+---
 
-## JSON mock format
-    {
-        "paths": ["/some/hardcoded/path", "/another/hardcoded/path"],
-        "verb": "POST",
-        "body": {
-            "user": 123,
-            "name": "bk9"
-        },
-        "headers": {
-            "Content-Type": "application/json",
-            "key": "value", 
-            "anotherkey": "123"
-        },
-        "status": 200,
-        "print_request_body": true,
-        "response_time" 100
-    }
+## Features
 
-- Paths: paths to match.
-- Verb: REST verb to match.
-- Body: Response body of the API.
-- Headers: Response headers of the API.
-- Status: Status code to return.
-- Print request body: Print request body to STDOUT 
+- **Terminal UI** — browse, create, edit, enable/disable and delete mocks without leaving the terminal
+- **Multi-mock per route** — multiple mocks can share the same path + verb; an interactive picker lets you choose which one to serve on each request
+- **Capture mode** — intercept unmapped requests and define a response live; the mock is saved to disk automatically. Also works on already-defined routes, letting you add variants without touching any file
+- **Enable / disable** — toggle mocks on and off instantly without deleting them
+- **Colored status codes** — 2xx green, 3xx yellow, 4xx orange, 5xx red
+- **Request log** — live scrollable log of every incoming request
+- **Headless mode** — run without the TUI for CI or scripted environments
 
-## Run
-`go run ./cmd/api/main.go -p=<port> -d=<path-to-mocks>` in the proyect root.
+---
+
+## Installation
+
+```bash
+go install github.com/brianknu/simple-mock-server/cmd/api@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/brianknu/simple-mock-server
+cd simple-mock-server
+go build -o simple-mock-server ./cmd/api
+```
+
+---
+
+## Usage
+
+```bash
+# TUI mode (default)
+simple-mock-server -p 8081 -d ./mocks
+
+# Headless mode (logs to stdout, no TUI)
+simple-mock-server -p 8081 -d ./mocks --no-tui
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-p` | `8081` | Port to listen on |
+| `-d` | — | Directory containing mock JSON files |
+| `--no-tui` | `false` | Disable the terminal UI |
+
+You can also set the mocks directory via environment variable:
+
+```bash
+export SIMPLE_MOCKS_LOCATION=./mocks
+simple-mock-server -p 8081
+```
+
+---
+
+## Mock format
+
+Each `.json` file in the mocks directory defines one mock:
+
+```json
+{
+    "paths": ["/api/users", "/api/v2/users"],
+    "verb": "GET",
+    "status": 200,
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "body": {
+        "users": [{ "id": 1, "name": "alice" }]
+    },
+    "response_time": 150,
+    "print_request_body": false,
+    "disabled": false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `paths` | `[]string` | One or more URL paths this mock matches |
+| `verb` | `string` | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, …) |
+| `status` | `int` | HTTP status code to return |
+| `headers` | `object` | Response headers |
+| `body` | `any` | JSON response body |
+| `response_time` | `int` | Delay in milliseconds before responding |
+| `print_request_body` | `bool` | Print the incoming request body to the log |
+| `disabled` | `bool` | When `true`, the mock is loaded but not served (omit to default to enabled) |
+
+> Multiple JSON files can define mocks for the same path + verb. The TUI will ask you to pick one on each request.
+
+---
+
+## Keyboard shortcuts
+
+### Mocks tab
+
+| Key | Action |
+|-----|--------|
+| `n` | Create new mock |
+| `e` | Edit selected mock |
+| `d` | Show mock details |
+| `space` | Enable / disable selected mock |
+| `x` | Delete selected mock |
+| `r` | Reload mocks from disk |
+| `i` | Toggle capture mode |
+| `↑` / `↓` | Navigate list |
+
+### Create / Edit form
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Cycle between fields |
+| `←` / `→` | Cycle HTTP verb (on Method field) |
+| `ctrl+s` | Save mock |
+| `esc` | Cancel |
+
+### Request Log tab
+
+| Key | Action |
+|-----|--------|
+| `c` | Clear log |
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `tab` / `shift+tab` | Switch tabs |
+| `?` | Toggle help |
+| `q` / `ctrl+c` | Quit |
+
+---
+
+## Capture mode
+
+Press `i` to toggle capture mode. While active:
+
+- Requests to **unmapped routes** are intercepted — the TUI opens a pre-filled form where you define the response. The mock is saved to disk and the HTTP request is answered immediately.
+- Requests to **already-mapped routes** show the mock picker with an extra **"+ Define new mock"** option. Selecting it opens the same capture form, creating a new variant alongside the existing mock.
+
+---
+
+## License
+
+MIT

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -38,7 +38,7 @@ func runHeadless(port int, directory string) {
 		log.Fatalf("Could not start simple-mock-server: %s", err)
 	}
 	mux := router.NewDynamicMux()
-	router.RegisterMocks(mux, mocks, nil)
+	router.RegisterMocks(mux, mocks, router.RouteConfig{})
 	addr := fmt.Sprintf(":%d", port)
 	log.Printf("Starting server on %s.", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {

--- a/docs/adr/001-capture-mode.md
+++ b/docs/adr/001-capture-mode.md
@@ -1,0 +1,72 @@
+# ADR 001: Capture Mode — Interactive Mock Creation from Live Requests
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-25
+
+## Context
+
+The simple-mock-server serves predefined mock responses from JSON files. When a request arrives that doesn't match any mock, the server returns a 404. Users building mocks iteratively — for example, while developing a frontend against a not-yet-implemented backend — must manually create each mock file or use the TUI form, which requires knowing the exact endpoints in advance.
+
+We wanted a "learning mode" where the server captures unmatched requests and lets the user define mock responses on the fly, directly from the TUI, so that the mock library grows organically as the application under development makes requests.
+
+## Decision
+
+We introduce **Capture Mode**, toggled with the `i` key in the TUI. When enabled, unmatched HTTP requests no longer receive a 404. Instead:
+
+1. The HTTP handler captures the request (method, path, headers, body) and **blocks**, waiting for the user to define a response.
+2. The TUI receives a notification, switches to the Create/Edit form pre-filled with the request's method and path, and shows a "LIVE REQUEST" banner.
+3. The user fills in the response (status code, headers, body) and saves with `ctrl+s`.
+4. The mock is saved to disk as a `.json` file and registered on the mux.
+5. The blocked HTTP handler receives the user-defined response and sends it to the original caller.
+6. The server continues listening for the next unmatched request.
+
+### Channel-based synchronization
+
+The core design challenge is coordinating the HTTP handler goroutine (which must wait) with the TUI running on the main goroutine. We use a **channel pair**:
+
+```
+HTTP handler goroutine                          TUI (main goroutine)
+──────────────────────                          ────────────────────
+Creates PendingRequest with ResponseCh(cap 1)
+  → sends to server.PendingCh ──────────────→  waitForPending() reads from PendingCh
+  blocks on <-ResponseCh                        Shows pre-filled form
+                                                User saves mock
+                                  ←──────────── Sends PendingResponse to ResponseCh
+  Writes HTTP response
+```
+
+- `PendingRequest.ResponseCh` is a buffered channel (capacity 1) so the TUI's send never blocks even if the HTTP client disconnected.
+- `server.PendingCh` is buffered (capacity 1). Overflow requests go to `pendingQueue` and are delivered one at a time after each completion.
+
+### Pluggable fallback handler on DynamicMux
+
+Rather than coupling the router to capture mode, we added a `NotFoundHandler http.HandlerFunc` field to `DynamicMux`. When set, it is called instead of the default `http.NotFound`. This keeps the router generic and testable.
+
+### Request serialization
+
+Only one unmatched request is presented to the user at a time. Additional requests queue in `pendingQueue` and their HTTP handler goroutines block on their individual `ResponseCh` channels. After the user handles one, `NextPending()` delivers the next. This avoids overwhelming the user and keeps the TUI interaction sequential.
+
+## Consequences
+
+### Positive
+
+- Users can build a mock library incrementally by simply running their application against the mock server — no upfront endpoint knowledge required.
+- The mock is saved to disk immediately, so it persists across server restarts.
+- The original HTTP caller receives the user-defined response, enabling real-time development feedback.
+- The `NotFoundHandler` pattern is reusable for other fallback behaviors in the future.
+
+### Negative
+
+- The HTTP caller blocks until the user responds (or the client times out). This is by design but means slow user interaction leads to client timeouts. The mock is still saved even if the client disconnects.
+- Only available in TUI mode — headless mode does not support capture mode since there is no interactive UI.
+- Serialized request handling means concurrent unmatched requests queue up. In practice this is acceptable since mock creation is a development-time activity.
+
+### Risks
+
+- If the user forgets capture mode is on, unmatched requests will hang instead of returning 404. The status bar indicator ("CAPTURE") mitigates this.
+- Pressing `esc` on the form cancels the pending request (returns 404) and discards the mock. This is intentional — the user must save to create the mock.

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -61,7 +61,14 @@ func SaveMockToFS(directory string, m Mock) (string, error) {
 		if len(m.Paths) > 0 {
 			name = strings.ReplaceAll(strings.Trim(m.Paths[0], "/"), "/", "_")
 		}
-		filename = filepath.Join(directory, fmt.Sprintf("%s_%s.json", m.Verb, name))
+		base := filepath.Join(directory, fmt.Sprintf("%s_%s", m.Verb, name))
+		filename = base + ".json"
+		for i := 2; ; i++ {
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				break
+			}
+			filename = fmt.Sprintf("%s_%d.json", base, i)
+		}
 	}
 
 	data, err := json.MarshalIndent(m, "", "    ")

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -17,6 +17,7 @@ type Mock struct {
 	Status           int               `json:"status"`
 	PrintRequestBody bool              `json:"print_request_body"`
 	ResponseTime     int               `json:"response_time"`
+	Disabled         bool              `json:"disabled,omitempty"`
 	SourceFile       string            `json:"-"`
 }
 

--- a/internal/router/mux.go
+++ b/internal/router/mux.go
@@ -8,8 +8,9 @@ import (
 // DynamicMux is an HTTP request multiplexer that supports dynamic route
 // registration and removal at runtime. It is safe for concurrent use.
 type DynamicMux struct {
-	mu       sync.RWMutex
-	handlers map[string]http.HandlerFunc
+	mu              sync.RWMutex
+	handlers        map[string]http.HandlerFunc
+	NotFoundHandler http.HandlerFunc
 }
 
 func NewDynamicMux() *DynamicMux {
@@ -37,6 +38,8 @@ func (m *DynamicMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if ok {
 		handler(w, r)
+	} else if m.NotFoundHandler != nil {
+		m.NotFoundHandler(w, r)
 	} else {
 		http.NotFound(w, r)
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -23,50 +23,116 @@ type RequestEntry struct {
 	ResponseTime int
 }
 
-func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, logger RequestLogger) {
+// MockSelector is called when the user must choose among mocks.
+// Return values:
+//
+//	>= 0  index of the selected mock
+//	-1    cancel (respond with 404)
+//	-2    define a new mock (triggers Fallback handler)
+type MockSelector func(path string, verb string, mocks []mock.Mock) int
+
+// RouteConfig holds the options for RegisterMocks.
+type RouteConfig struct {
+	Logger       RequestLogger
+	Selector     MockSelector
+	CaptureCheck func() bool      // returns true when capture mode is on
+	Fallback     http.HandlerFunc // called when selector returns -2 (define new)
+}
+
+func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, cfg RouteConfig) {
+	// Group mocks by path
+	grouped := make(map[string][]mock.Mock)
+
 	for _, m := range mocks {
-		m := m // capture loop variable
 		for _, path := range m.Paths {
-			mux.Handle(path, func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != m.Verb {
-					w.WriteHeader(http.StatusMethodNotAllowed)
+			grouped[path] = append(grouped[path], m)
+		}
+	}
+
+	for path, pathMocks := range grouped {
+		pathMocks := pathMocks // capture
+		path := path
+		mux.Handle(path, func(w http.ResponseWriter, r *http.Request) {
+			// Filter by verb
+			var matches []mock.Mock
+			for _, m := range pathMocks {
+				if m.Verb == r.Method {
+					matches = append(matches, m)
+				}
+			}
+
+			captureOn := cfg.CaptureCheck != nil && cfg.CaptureCheck()
+
+			if len(matches) == 0 {
+				// No verb match — in capture mode, let user define a new mock
+				if captureOn && cfg.Fallback != nil {
+					cfg.Fallback(w, r)
 					return
 				}
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 
-				for hk, hv := range m.Headers {
-					w.Header().Set(hk, hv)
-				}
-				if m.ResponseTime > 0 {
-					time.Sleep(time.Duration(m.ResponseTime) * time.Millisecond)
-				}
-				w.WriteHeader(m.Status)
-				json.NewEncoder(w).Encode(m.Body)
+			// Single match and capture is off → serve directly
+			if len(matches) == 1 && !captureOn {
+				serveMock(w, r, matches[0], cfg.Logger)
+				return
+			}
 
-				var bodyStr string
-				if m.PrintRequestBody {
-					if b, err := io.ReadAll(r.Body); err == nil {
-						bodyStr = string(b)
-					}
+			// Multiple matches, or capture mode is on → ask user to pick
+			if cfg.Selector != nil {
+				idx := cfg.Selector(path, r.Method, matches)
+				switch {
+				case idx == -2 && cfg.Fallback != nil:
+					cfg.Fallback(w, r)
+					return
+				case idx < 0 || idx >= len(matches):
+					http.NotFound(w, r)
+					return
+				default:
+					serveMock(w, r, matches[idx], cfg.Logger)
+					return
 				}
+			}
 
-				entry := RequestEntry{
-					Method:       m.Verb,
-					Path:         r.RequestURI,
-					Status:       m.Status,
-					RequestBody:  bodyStr,
-					ResponseTime: m.ResponseTime,
-				}
+			// No selector (headless) → first match
+			serveMock(w, r, matches[0], cfg.Logger)
+		})
+	}
+}
 
-				if logger != nil {
-					logger.Log(entry)
-				} else {
-					if bodyStr != "" {
-						log.Printf("%s %s\n%s", entry.Method, entry.Path, bodyStr)
-					} else {
-						log.Printf("%s %s", entry.Method, entry.Path)
-					}
-				}
-			})
+func serveMock(w http.ResponseWriter, r *http.Request, m mock.Mock, logger RequestLogger) {
+	for hk, hv := range m.Headers {
+		w.Header().Set(hk, hv)
+	}
+	if m.ResponseTime > 0 {
+		time.Sleep(time.Duration(m.ResponseTime) * time.Millisecond)
+	}
+	w.WriteHeader(m.Status)
+	json.NewEncoder(w).Encode(m.Body)
+
+	var bodyStr string
+	if m.PrintRequestBody {
+		if b, err := io.ReadAll(r.Body); err == nil {
+			bodyStr = string(b)
+		}
+	}
+
+	entry := RequestEntry{
+		Method:       m.Verb,
+		Path:         r.RequestURI,
+		Status:       m.Status,
+		RequestBody:  bodyStr,
+		ResponseTime: m.ResponseTime,
+	}
+
+	if logger != nil {
+		logger.Log(entry)
+	} else {
+		if bodyStr != "" {
+			log.Printf("%s %s\n%s", entry.Method, entry.Path, bodyStr)
+		} else {
+			log.Printf("%s %s", entry.Method, entry.Path)
 		}
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -44,6 +44,9 @@ func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, cfg RouteConfig) {
 	grouped := make(map[string][]mock.Mock)
 
 	for _, m := range mocks {
+		if m.Disabled {
+			continue
+		}
 		for _, path := range m.Paths {
 			grouped[path] = append(grouped[path], m)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -12,6 +13,24 @@ import (
 	"simple-mock-server/internal/router"
 )
 
+// PendingRequest represents an unmatched HTTP request waiting for the user
+// to define a mock response via the TUI (capture mode).
+type PendingRequest struct {
+	Method     string
+	Path       string
+	Headers    http.Header
+	Body       string
+	ResponseCh chan PendingResponse
+}
+
+// PendingResponse is the response defined by the user for a pending request.
+type PendingResponse struct {
+	Status  int
+	Headers map[string]string
+	Body    []byte
+	Cancel  bool
+}
+
 type Server struct {
 	mu         sync.RWMutex
 	mocks      []mock.Mock
@@ -20,20 +39,62 @@ type Server struct {
 	MocksDir   string
 	Port       int
 	ReqLog     *RequestLog
+
+	captureMode bool
+	pendingMu     sync.Mutex
+	PendingCh     chan PendingRequest
+	pendingQueue  []*PendingRequest
 }
 
 func New(port int, mocksDir string) *Server {
 	mux := router.NewDynamicMux()
-	return &Server{
-		mux:      mux,
-		MocksDir: mocksDir,
-		Port:     port,
-		ReqLog:   NewRequestLog(1000),
+	s := &Server{
+		mux:       mux,
+		MocksDir:  mocksDir,
+		Port:      port,
+		ReqLog:    NewRequestLog(1000),
+		PendingCh: make(chan PendingRequest, 1),
 		httpServer: &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),
 			Handler: mux,
 		},
 	}
+
+	mux.NotFoundHandler = func(w http.ResponseWriter, r *http.Request) {
+		if !s.CaptureMode() {
+			http.NotFound(w, r)
+			return
+		}
+
+		bodyBytes, _ := io.ReadAll(r.Body)
+
+		pr := &PendingRequest{
+			Method:     r.Method,
+			Path:       r.URL.Path,
+			Headers:    r.Header.Clone(),
+			Body:       string(bodyBytes),
+			ResponseCh: make(chan PendingResponse, 1),
+		}
+
+		s.EnqueuePending(pr)
+
+		select {
+		case resp := <-pr.ResponseCh:
+			if resp.Cancel {
+				http.NotFound(w, r)
+				return
+			}
+			for k, v := range resp.Headers {
+				w.Header().Set(k, v)
+			}
+			w.WriteHeader(resp.Status)
+			w.Write(resp.Body)
+		case <-r.Context().Done():
+			// Client disconnected; mock will still be saved if user completes the form
+		}
+	}
+
+	return s
 }
 
 // LoadAndRegister loads mocks from disk and registers them on the mux.
@@ -118,4 +179,53 @@ func (s *Server) MockCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.mocks)
+}
+
+// CaptureMode returns whether capture mode is enabled.
+func (s *Server) CaptureMode() bool {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	return s.captureMode
+}
+
+// SetCaptureMode toggles capture mode. When turning off, queued requests are cancelled.
+func (s *Server) SetCaptureMode(on bool) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	s.captureMode = on
+	if !on {
+		// Flush queued requests with cancel
+		for _, pr := range s.pendingQueue {
+			select {
+			case pr.ResponseCh <- PendingResponse{Cancel: true}:
+			default:
+			}
+		}
+		s.pendingQueue = nil
+	}
+}
+
+// EnqueuePending sends a pending request to the TUI or queues it if the TUI is busy.
+func (s *Server) EnqueuePending(pr *PendingRequest) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	select {
+	case s.PendingCh <- *pr:
+	default:
+		s.pendingQueue = append(s.pendingQueue, pr)
+	}
+}
+
+// NextPending sends the next queued request to PendingCh, if any.
+func (s *Server) NextPending() {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	if len(s.pendingQueue) > 0 {
+		next := s.pendingQueue[0]
+		s.pendingQueue = s.pendingQueue[1:]
+		select {
+		case s.PendingCh <- *next:
+		default:
+		}
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,37 @@ import (
 	"simple-mock-server/internal/router"
 )
 
+// handleCapture blocks the HTTP handler until the TUI user defines a response.
+// It is used both by the NotFoundHandler and when capture mode intercepts a matched route.
+func (s *Server) handleCapture(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+
+	pr := &PendingRequest{
+		Method:     r.Method,
+		Path:       r.URL.Path,
+		Headers:    r.Header.Clone(),
+		Body:       string(bodyBytes),
+		ResponseCh: make(chan PendingResponse, 1),
+	}
+
+	s.EnqueuePending(pr)
+
+	select {
+	case resp := <-pr.ResponseCh:
+		if resp.Cancel {
+			http.NotFound(w, r)
+			return
+		}
+		for k, v := range resp.Headers {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(resp.Status)
+		w.Write(resp.Body)
+	case <-r.Context().Done():
+		// Client disconnected; mock will still be saved if user completes the form
+	}
+}
+
 // PendingRequest represents an unmatched HTTP request waiting for the user
 // to define a mock response via the TUI (capture mode).
 type PendingRequest struct {
@@ -31,6 +62,15 @@ type PendingResponse struct {
 	Cancel  bool
 }
 
+// SelectionRequest is sent to the TUI when multiple mocks match a request.
+type SelectionRequest struct {
+	Path        string
+	Verb        string
+	Mocks       []mock.Mock
+	CaptureMode bool // true when capture mode is on; picker shows "Define new" option
+	ResponseCh  chan int // index of selected mock, -1 to cancel, -2 to define new
+}
+
 type Server struct {
 	mu         sync.RWMutex
 	mocks      []mock.Mock
@@ -44,16 +84,19 @@ type Server struct {
 	pendingMu     sync.Mutex
 	PendingCh     chan PendingRequest
 	pendingQueue  []*PendingRequest
+
+	SelectionCh chan SelectionRequest
 }
 
 func New(port int, mocksDir string) *Server {
 	mux := router.NewDynamicMux()
 	s := &Server{
-		mux:       mux,
-		MocksDir:  mocksDir,
-		Port:      port,
-		ReqLog:    NewRequestLog(1000),
-		PendingCh: make(chan PendingRequest, 1),
+		mux:         mux,
+		MocksDir:    mocksDir,
+		Port:        port,
+		ReqLog:      NewRequestLog(1000),
+		PendingCh:   make(chan PendingRequest, 1),
+		SelectionCh: make(chan SelectionRequest, 1),
 		httpServer: &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),
 			Handler: mux,
@@ -65,33 +108,7 @@ func New(port int, mocksDir string) *Server {
 			http.NotFound(w, r)
 			return
 		}
-
-		bodyBytes, _ := io.ReadAll(r.Body)
-
-		pr := &PendingRequest{
-			Method:     r.Method,
-			Path:       r.URL.Path,
-			Headers:    r.Header.Clone(),
-			Body:       string(bodyBytes),
-			ResponseCh: make(chan PendingResponse, 1),
-		}
-
-		s.EnqueuePending(pr)
-
-		select {
-		case resp := <-pr.ResponseCh:
-			if resp.Cancel {
-				http.NotFound(w, r)
-				return
-			}
-			for k, v := range resp.Headers {
-				w.Header().Set(k, v)
-			}
-			w.WriteHeader(resp.Status)
-			w.Write(resp.Body)
-		case <-r.Context().Done():
-			// Client disconnected; mock will still be saved if user completes the form
-		}
+		s.handleCapture(w, r)
 	}
 
 	return s
@@ -118,7 +135,26 @@ func (s *Server) rebuildRoutes() {
 	s.mu.RUnlock()
 
 	s.mux.Clear()
-	router.RegisterMocks(s.mux, mocks, s.ReqLog)
+	router.RegisterMocks(s.mux, mocks, router.RouteConfig{
+		Logger:       s.ReqLog,
+		Selector:     s.selectMock,
+		CaptureCheck: s.CaptureMode,
+		Fallback:     s.handleCapture,
+	})
+}
+
+// selectMock is the MockSelector used in TUI mode. It sends a SelectionRequest
+// to the TUI and blocks until the user picks a mock.
+func (s *Server) selectMock(path string, verb string, mocks []mock.Mock) int {
+	req := SelectionRequest{
+		Path:        path,
+		Verb:        verb,
+		Mocks:       mocks,
+		CaptureMode: s.CaptureMode(),
+		ResponseCh:  make(chan int, 1),
+	}
+	s.SelectionCh <- req
+	return <-req.ResponseCh
 }
 
 // Start begins serving HTTP in a new goroutine.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -198,6 +198,16 @@ func (s *Server) UpdateMock(index int, m mock.Mock) {
 	s.rebuildRoutes()
 }
 
+func (s *Server) ToggleMock(index int) {
+	s.mu.Lock()
+	if index >= 0 && index < len(s.mocks) {
+		s.mocks[index].Disabled = !s.mocks[index].Disabled
+		mock.SaveMockToFS(s.MocksDir, s.mocks[index])
+	}
+	s.mu.Unlock()
+	s.rebuildRoutes()
+}
+
 func (s *Server) DeleteMock(index int) {
 	s.mu.Lock()
 	if index >= 0 && index < len(s.mocks) {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -17,6 +17,7 @@ type keyMap struct {
 	Back      key.Binding
 	Up        key.Binding
 	Down      key.Binding
+	Capture key.Binding
 }
 
 var keys = keyMap{
@@ -75,5 +76,9 @@ var keys = keyMap{
 	Down: key.NewBinding(
 		key.WithKeys("down"),
 		key.WithHelp("↓", "down"),
+	),
+	Capture: key.NewBinding(
+		key.WithKeys("i"),
+		key.WithHelp("i", "toggle capture mode"),
 	),
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -3,21 +3,23 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	Quit      key.Binding
-	Tab       key.Binding
-	ShiftTab  key.Binding
-	Help      key.Binding
-	New       key.Binding
-	Edit      key.Binding
-	Delete    key.Binding
-	Reload    key.Binding
-	Clear     key.Binding
-	Save      key.Binding
-	Send      key.Binding
-	Back      key.Binding
-	Up        key.Binding
-	Down      key.Binding
-	Capture key.Binding
+	Quit     key.Binding
+	Tab      key.Binding
+	ShiftTab key.Binding
+	Help     key.Binding
+	New      key.Binding
+	Edit     key.Binding
+	Detail   key.Binding
+	Delete   key.Binding
+	Reload   key.Binding
+	Clear    key.Binding
+	Save     key.Binding
+	Send     key.Binding
+	Back     key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Capture  key.Binding
+	Toggle   key.Binding
 }
 
 var keys = keyMap{
@@ -45,9 +47,13 @@ var keys = keyMap{
 		key.WithKeys("e"),
 		key.WithHelp("e", "edit mock"),
 	),
-	Delete: key.NewBinding(
+	Detail: key.NewBinding(
 		key.WithKeys("d"),
-		key.WithHelp("d", "delete mock"),
+		key.WithHelp("d", "detail"),
+	),
+	Delete: key.NewBinding(
+		key.WithKeys("x"),
+		key.WithHelp("x", "delete mock"),
 	),
 	Reload: key.NewBinding(
 		key.WithKeys("r"),
@@ -80,5 +86,9 @@ var keys = keyMap{
 	Capture: key.NewBinding(
 		key.WithKeys("i"),
 		key.WithHelp("i", "toggle capture mode"),
+	),
+	Toggle: key.NewBinding(
+		key.WithKeys(" "),
+		key.WithHelp("space", "enable/disable mock"),
 	),
 }

--- a/internal/tui/mockform.go
+++ b/internal/tui/mockform.go
@@ -43,6 +43,9 @@ type mockFormModel struct {
 	width        int
 	message      string
 	sourceFile   string
+
+	isPendingResponse bool
+	pendingInfo       string
 }
 
 type mockSavedMsg string
@@ -279,12 +282,43 @@ func (m mockFormModel) save() tea.Cmd {
 	}
 }
 
+func (m mockFormModel) buildResponse() server.PendingResponse {
+	status, _ := strconv.Atoi(m.statusInput.Value())
+	if status == 0 {
+		status = 200
+	}
+
+	headers := make(map[string]string)
+	for _, line := range strings.Split(m.headersArea.Value(), "\n") {
+		if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+			headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+
+	bodyStr := strings.TrimSpace(m.bodyArea.Value())
+	var body []byte
+	if bodyStr != "" {
+		body = []byte(bodyStr)
+	}
+
+	return server.PendingResponse{
+		Status:  status,
+		Headers: headers,
+		Body:    body,
+	}
+}
+
 func (m mockFormModel) View() string {
 	if !m.editing {
 		return "  Press 'n' on the Mocks tab to create a new mock, or 'e' to edit one.\n  You can also press Enter here to start a new mock."
 	}
 
 	var b strings.Builder
+
+	if m.isPendingResponse {
+		b.WriteString(liveRequestBannerStyle.Render("LIVE REQUEST: " + m.pendingInfo + " is waiting for your response"))
+		b.WriteString("\n\n")
+	}
 
 	title := "Create New Mock"
 	if m.editIndex >= 0 {

--- a/internal/tui/mocklist.go
+++ b/internal/tui/mocklist.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -13,12 +14,13 @@ import (
 )
 
 type mockListModel struct {
-	srv      *server.Server
-	mocks    []mock.Mock
-	cursor   int
-	width    int
-	height   int
-	message  string
+	srv        *server.Server
+	mocks      []mock.Mock
+	cursor     int
+	width      int
+	height     int
+	message    string
+	showDetail bool
 }
 
 func newMockListModel(srv *server.Server) mockListModel {
@@ -31,6 +33,11 @@ func newMockListModel(srv *server.Server) mockListModel {
 func (m mockListModel) Update(msg tea.Msg) (mockListModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if m.showDetail {
+			// Any key closes the detail view
+			m.showDetail = false
+			return m, nil
+		}
 		switch {
 		case key.Matches(msg, keys.Up):
 			if m.cursor > 0 {
@@ -39,6 +46,15 @@ func (m mockListModel) Update(msg tea.Msg) (mockListModel, tea.Cmd) {
 		case key.Matches(msg, keys.Down):
 			if m.cursor < len(m.mocks)-1 {
 				m.cursor++
+			}
+		case key.Matches(msg, keys.Detail):
+			if len(m.mocks) > 0 {
+				m.showDetail = true
+			}
+		case key.Matches(msg, keys.Toggle):
+			if len(m.mocks) > 0 {
+				m.srv.ToggleMock(m.cursor)
+				m.mocks = m.srv.Mocks()
 			}
 		case key.Matches(msg, keys.Delete):
 			if len(m.mocks) > 0 {
@@ -68,12 +84,19 @@ func (m mockListModel) Update(msg tea.Msg) (mockListModel, tea.Cmd) {
 }
 
 func (m mockListModel) View() string {
+	if m.showDetail && len(m.mocks) > 0 {
+		return m.detailView(m.mocks[m.cursor])
+	}
+	return m.listView()
+}
+
+func (m mockListModel) listView() string {
 	var b strings.Builder
 
-	header := fmt.Sprintf("  %-8s %-35s %-8s %-12s %s", "METHOD", "PATHS", "STATUS", "DELAY(ms)", "FILE")
-	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("252")).Render(header))
+	header := fmt.Sprintf("  %-3s %-8s %-40s %-8s %s", "", "METHOD", "PATHS", "STATUS", "DELAY(ms)")
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8F8F2")).Render(header))
 	b.WriteString("\n")
-	b.WriteString(strings.Repeat("─", min(m.width, 90)))
+	b.WriteString(strings.Repeat("─", min(m.width, 80)))
 	b.WriteString("\n")
 
 	if len(m.mocks) == 0 {
@@ -97,21 +120,44 @@ func (m mockListModel) View() string {
 			cursor = "▸ "
 		}
 
-		paths := strings.Join(mk.Paths, ", ")
-		if len(paths) > 33 {
-			paths = paths[:30] + "..."
+		// Truncate paths before padding so column width is stable
+		pathStr := strings.Join(mk.Paths, ", ")
+		if len(pathStr) > 38 {
+			pathStr = pathStr[:35] + "..."
 		}
 
-		source := mk.SourceFile
-		if len(source) > 20 {
-			source = "..." + source[len(source)-17:]
+		// Pad each column to its fixed width BEFORE styling.
+		// fmt.Sprintf with %-Ns counts bytes, not visual width, so styled strings
+		// must never be passed to %-Ns — only plain strings get padded here.
+		dotRaw := "●"
+		dotColor := lipgloss.Color("#50FA7B")
+		if mk.Disabled {
+			dotRaw = "○"
+			dotColor = lipgloss.Color("#44475A")
+		}
+		dot := lipgloss.NewStyle().Foreground(dotColor).Render(dotRaw)
+
+		verbPadded := fmt.Sprintf("%-8s", mk.Verb)
+		pathPadded := fmt.Sprintf("%-40s", pathStr)
+		statusPadded := fmt.Sprintf("%-8d", mk.Status)
+		delayPadded := fmt.Sprintf("%-12d", mk.ResponseTime)
+
+		var verb, paths, status string
+		if mk.Disabled {
+			dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4"))
+			verb = dim.Render(verbPadded)
+			paths = dim.Render(pathPadded)
+			status = dim.Render(statusPadded)
+		} else {
+			verb = methodStyle(mk.Verb).Render(verbPadded)
+			paths = pathPadded
+			status = statusStyle(mk.Status).Render(statusPadded)
 		}
 
-		verb := methodStyle(mk.Verb).Render(fmt.Sprintf("%-8s", mk.Verb))
-		line := fmt.Sprintf("%s%s %-35s %-8d %-12d %s", cursor, verb, paths, mk.Status, mk.ResponseTime, source)
+		line := cursor + dot + " " + verb + " " + paths + " " + status + " " + delayPadded
 
 		if i == m.cursor {
-			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(line)
+			line = lipgloss.NewStyle().Background(lipgloss.Color("#44475A")).Render(line)
 		}
 
 		b.WriteString(line)
@@ -123,7 +169,68 @@ func (m mockListModel) View() string {
 	}
 
 	b.WriteString("\n\n")
-	b.WriteString(helpStyle.Render("  n: new  e: edit  d: delete  r: reload  i: capture  ↑/↓: navigate"))
+	b.WriteString(helpStyle.Render("  n: new  e: edit  d: detail  space: toggle  x: delete  r: reload  i: capture  ↑/↓: navigate"))
+
+	return b.String()
+}
+
+func (m mockListModel) detailView(mk mock.Mock) string {
+	var b strings.Builder
+
+	b.WriteString(titleStyle.Render("Mock Detail"))
+	b.WriteString("\n\n")
+
+	row := func(label, value string) string {
+		l := lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Bold(true).Render(fmt.Sprintf("  %-14s", label))
+		return l + " " + value
+	}
+
+	stateStr := lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Bold(true).Render("● enabled")
+	if mk.Disabled {
+		stateStr = lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Render("○ disabled")
+	}
+	b.WriteString(row("State", stateStr))
+	b.WriteString("\n")
+
+	verb := methodStyle(mk.Verb).Render(mk.Verb)
+	b.WriteString(row("Method", verb))
+	b.WriteString("\n")
+
+	b.WriteString(row("Paths", lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(strings.Join(mk.Paths, ", "))))
+	b.WriteString("\n")
+
+	b.WriteString(row("Status", statusStyle(mk.Status).Render(fmt.Sprintf("%d", mk.Status))))
+	b.WriteString("\n")
+
+	b.WriteString(row("Delay", lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(fmt.Sprintf("%d ms", mk.ResponseTime))))
+	b.WriteString("\n")
+
+	b.WriteString(row("File", lipgloss.NewStyle().Foreground(lipgloss.Color("#BD93F9")).Render(mk.SourceFile)))
+	b.WriteString("\n")
+
+	if len(mk.Headers) > 0 {
+		b.WriteString(row("Headers", ""))
+		b.WriteString("\n")
+		for k, v := range mk.Headers {
+			b.WriteString(fmt.Sprintf("    %s: %s\n",
+				lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Render(k),
+				lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(v),
+			))
+		}
+	}
+
+	if mk.Body != nil {
+		bodyBytes, err := json.MarshalIndent(mk.Body, "    ", "  ")
+		if err == nil {
+			b.WriteString(row("Body", ""))
+			b.WriteString("\n")
+			b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Render("    " + string(bodyBytes)))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  any key to close"))
 
 	return b.String()
 }
@@ -135,4 +242,19 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// detailActive reports whether the detail overlay is open.
+// Used by tui.go to suppress global keybindings.
+func (m mockListModel) detailActive() bool {
+	return m.showDetail
+}
+
+// selectedMock returns the currently selected mock.
+func (m mockListModel) selectedMock() *mock.Mock {
+	if len(m.mocks) == 0 {
+		return nil
+	}
+	mk := m.mocks[m.cursor]
+	return &mk
 }

--- a/internal/tui/mocklist.go
+++ b/internal/tui/mocklist.go
@@ -123,7 +123,7 @@ func (m mockListModel) View() string {
 	}
 
 	b.WriteString("\n\n")
-	b.WriteString(helpStyle.Render("  n: new  e: edit  d: delete  r: reload  ↑/↓: navigate"))
+	b.WriteString(helpStyle.Render("  n: new  e: edit  d: delete  r: reload  i: capture  ↑/↓: navigate"))
 
 	return b.String()
 }

--- a/internal/tui/mockpicker.go
+++ b/internal/tui/mockpicker.go
@@ -1,0 +1,168 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"simple-mock-server/internal/mock"
+	"simple-mock-server/internal/server"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type selectionRequestMsg server.SelectionRequest
+
+type selectionDoneMsg struct {
+	defineNew bool // true when user chose "+ Define new mock"
+	path      string
+	verb      string
+}
+
+type mockPickerModel struct {
+	active      bool
+	mocks       []mock.Mock
+	path        string
+	verb        string
+	captureMode bool
+	cursor      int
+	width       int
+	height      int
+
+	responseCh chan int
+}
+
+func newMockPickerModel() mockPickerModel {
+	return mockPickerModel{}
+}
+
+func (m *mockPickerModel) activate(req server.SelectionRequest, width, height int) {
+	m.active = true
+	m.mocks = req.Mocks
+	m.path = req.Path
+	m.verb = req.Verb
+	m.captureMode = req.CaptureMode
+	m.cursor = 0
+	m.width = width
+	m.height = height
+	m.responseCh = req.ResponseCh
+}
+
+// totalItems returns the number of selectable rows (mocks + optional "define new").
+func (m mockPickerModel) totalItems() int {
+	if m.captureMode {
+		return len(m.mocks) + 1
+	}
+	return len(m.mocks)
+}
+
+func (m mockPickerModel) Update(msg tea.Msg) (mockPickerModel, tea.Cmd) {
+	if !m.active {
+		return m, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, keys.Up):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case key.Matches(msg, keys.Down):
+			if m.cursor < m.totalItems()-1 {
+				m.cursor++
+			}
+		case msg.String() == "enter":
+			isDefineNew := m.captureMode && m.cursor == len(m.mocks)
+			if isDefineNew {
+				m.responseCh <- -2
+				m.active = false
+				return m, func() tea.Msg {
+					return selectionDoneMsg{defineNew: true, path: m.path, verb: m.verb}
+				}
+			}
+			m.responseCh <- m.cursor
+			m.active = false
+			return m, func() tea.Msg { return selectionDoneMsg{} }
+		case key.Matches(msg, keys.Back):
+			m.responseCh <- -1
+			m.active = false
+			return m, func() tea.Msg { return selectionDoneMsg{} }
+		}
+	}
+
+	return m, nil
+}
+
+func (m mockPickerModel) View() string {
+	if !m.active {
+		return ""
+	}
+
+	var b strings.Builder
+
+	banner := fmt.Sprintf("SELECT MOCK: %s %s", m.verb, m.path)
+	b.WriteString(liveRequestBannerStyle.Render(banner))
+	b.WriteString("\n\n")
+
+	header := fmt.Sprintf("  %-4s %-8s %-12s %-10s %s", "#", "STATUS", "DELAY(ms)", "FILE", "BODY")
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("252")).Render(header))
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("─", min(m.width, 90)))
+	b.WriteString("\n")
+
+	for i, mk := range m.mocks {
+		cursor := "  "
+		if i == m.cursor {
+			cursor = "▸ "
+		}
+
+		source := mk.SourceFile
+		if len(source) > 20 {
+			source = "..." + source[len(source)-17:]
+		}
+
+		bodyPreview := ""
+		if mk.Body != nil {
+			if bodyBytes, err := json.Marshal(mk.Body); err == nil {
+				bodyPreview = string(bodyBytes)
+				if len(bodyPreview) > 40 {
+					bodyPreview = bodyPreview[:37] + "..."
+				}
+			}
+		}
+
+		line := fmt.Sprintf("%s%-4d %-8d %-12d %-10s %s", cursor, i+1, mk.Status, mk.ResponseTime, source, bodyPreview)
+
+		if i == m.cursor {
+			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(line)
+		}
+
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	// "+ Define new mock" option in capture mode
+	if m.captureMode {
+		b.WriteString(strings.Repeat("─", min(m.width, 90)))
+		b.WriteString("\n")
+		defineIdx := len(m.mocks)
+		cursor := "  "
+		if m.cursor == defineIdx {
+			cursor = "▸ "
+		}
+		line := cursor + captureIndicatorStyle.Render("+ Define new mock for this request")
+		if m.cursor == defineIdx {
+			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(line)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  ↑/↓: navigate  enter: select  esc: cancel (404)"))
+
+	return b.String()
+}

--- a/internal/tui/mockpicker.go
+++ b/internal/tui/mockpicker.go
@@ -134,7 +134,8 @@ func (m mockPickerModel) View() string {
 			}
 		}
 
-		line := fmt.Sprintf("%s%-4d %-8d %-12d %-10s %s", cursor, i+1, mk.Status, mk.ResponseTime, source, bodyPreview)
+		status := statusStyle(mk.Status).Render(fmt.Sprintf("%-8d", mk.Status))
+		line := fmt.Sprintf("%s%-4d %s %-12d %-10s %s", cursor, i+1, status, mk.ResponseTime, source, bodyPreview)
 
 		if i == m.cursor {
 			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Render(line)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -52,6 +52,16 @@ var (
 	methodDefaultStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("252")).
 				Bold(true)
+
+	captureIndicatorStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("208")).
+				Bold(true)
+
+	liveRequestBannerStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color("208")).
+				Foreground(lipgloss.Color("0")).
+				Bold(true).
+				Padding(0, 1)
 )
 
 func methodStyle(method string) lipgloss.Style {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -71,6 +71,21 @@ var (
 				Padding(0, 1)
 )
 
+func statusStyle(code int) lipgloss.Style {
+	switch {
+	case code >= 500:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5555")).Bold(true)
+	case code >= 400:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FFB86C")).Bold(true)
+	case code >= 300:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#F1FA8C")).Bold(true)
+	case code >= 200:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Bold(true)
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4"))
+	}
+}
+
 func methodStyle(method string) lipgloss.Style {
 	switch method {
 	case "GET":

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,61 +5,68 @@ import "github.com/charmbracelet/lipgloss"
 var (
 	activeTabStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("205")).
+			Foreground(lipgloss.Color("#FF79C6")).
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderBottom(true).
+			BorderForeground(lipgloss.Color("#FF79C6")).
 			Padding(0, 2)
 
 	inactiveTabStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("240")).
+				Foreground(lipgloss.Color("#6272A4")).
 				Padding(0, 2)
 
 	statusBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("235")).
-			Foreground(lipgloss.Color("252")).
+			Background(lipgloss.Color("#282A36")).
+			Foreground(lipgloss.Color("#F8F8F2")).
 			Padding(0, 1).
 			Width(80)
 
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("99")).
+			Foreground(lipgloss.Color("#BD93F9")).
 			Padding(0, 1)
 
 	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
+			Foreground(lipgloss.Color("#6272A4"))
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196")).
+			Foreground(lipgloss.Color("#FF5555")).
 			Bold(true)
 
 	successStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("82"))
+			Foreground(lipgloss.Color("#50FA7B"))
 
 	methodGetStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("82")).
+			Foreground(lipgloss.Color("#50FA7B")).
 			Bold(true)
 
 	methodPostStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("208")).
+			Foreground(lipgloss.Color("#FFB86C")).
 			Bold(true)
 
 	methodPutStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(lipgloss.Color("#8BE9FD")).
 			Bold(true)
 
 	methodDeleteStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196")).
+				Foreground(lipgloss.Color("#FF5555")).
+				Bold(true)
+
+	methodPatchStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#F1FA8C")).
 				Bold(true)
 
 	methodDefaultStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("252")).
+				Foreground(lipgloss.Color("#BD93F9")).
 				Bold(true)
 
 	captureIndicatorStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("208")).
+				Foreground(lipgloss.Color("#FF79C6")).
 				Bold(true)
 
 	liveRequestBannerStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("208")).
-				Foreground(lipgloss.Color("0")).
+				Background(lipgloss.Color("#FF79C6")).
+				Foreground(lipgloss.Color("#282A36")).
 				Bold(true).
 				Padding(0, 1)
 )
@@ -74,6 +81,8 @@ func methodStyle(method string) lipgloss.Style {
 		return methodPutStyle
 	case "DELETE":
 		return methodDeleteStyle
+	case "PATCH":
+		return methodPatchStyle
 	default:
 		return methodDefaultStyle
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -20,6 +20,8 @@ const (
 
 var tabNames = []string{"Mocks", "Request Log", "Create/Edit"}
 
+type pendingRequestMsg server.PendingRequest
+
 type Model struct {
 	srv       *server.Server
 	activeTab int
@@ -30,7 +32,9 @@ type Model struct {
 	reqLog   requestLogModel
 	mockForm mockFormModel
 
-	showHelp bool
+	showHelp      bool
+	captureMode bool
+	pendingReq    *server.PendingRequest
 }
 
 func NewModel(srv *server.Server) Model {
@@ -47,6 +51,16 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.reqLog.waitForEntry(),
 	)
+}
+
+func (m Model) waitForPending() tea.Cmd {
+	return func() tea.Msg {
+		pr, ok := <-m.srv.PendingCh
+		if !ok {
+			return nil
+		}
+		return pendingRequestMsg(pr)
+	}
 }
 
 // inputActive returns true when a text input has focus and single-char keys
@@ -78,6 +92,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.activeTab == tabMockForm {
 				m.mockForm.editing = false
 				m.activeTab = tabMockList
+				// Cancel pending request if any
+				if m.pendingReq != nil {
+					m.pendingReq.ResponseCh <- server.PendingResponse{Cancel: true}
+					m.pendingReq = nil
+					m.srv.NextPending()
+				}
 				return m, nil
 			}
 		}
@@ -99,6 +119,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if key.Matches(msg, keys.ShiftTab) {
 				m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
 				m.onTabSwitch()
+				return m, nil
+			}
+			if key.Matches(msg, keys.Capture) && m.activeTab != tabMockForm {
+				m.captureMode = !m.captureMode
+				m.srv.SetCaptureMode(m.captureMode)
+				if m.captureMode {
+					return m, m.waitForPending()
+				}
 				return m, nil
 			}
 		}
@@ -126,11 +154,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.reqLog, cmd = m.reqLog.Update(msg)
 		return m, cmd
 
+	case pendingRequestMsg:
+		pr := server.PendingRequest(msg)
+		m.pendingReq = &pr
+
+		form := newMockFormModel(m.srv)
+		form.width = m.width
+		form.isPendingResponse = true
+		form.pendingInfo = fmt.Sprintf("%s %s", pr.Method, pr.Path)
+		// Set verb from request
+		for i, v := range verbs {
+			if v == pr.Method {
+				form.verbIndex = i
+				break
+			}
+		}
+		form.pathsInput.SetValue(pr.Path)
+		form.startEditing()
+		m.mockForm = form
+		m.activeTab = tabMockForm
+		return m, m.mockForm.Init()
+
 	case mockSavedMsg:
 		m.mockList.mocks = m.srv.Mocks()
 		m.mockList.message = string(msg)
 		m.mockForm.editing = false
 		m.activeTab = tabMockList
+
+		if m.pendingReq != nil {
+			resp := m.mockForm.buildResponse()
+			m.pendingReq.ResponseCh <- resp
+			m.pendingReq = nil
+			m.srv.NextPending()
+			return m, m.waitForPending()
+		}
 		return m, nil
 	}
 
@@ -183,7 +240,14 @@ func (m Model) View() string {
 
 	// Status bar
 	b.WriteString("\n")
-	status := fmt.Sprintf(" :%d | %d mocks loaded | ? help", m.srv.Port, m.srv.MockCount())
+	indicator := ""
+	if m.captureMode {
+		indicator = " | " + captureIndicatorStyle.Render("CAPTURE")
+		if m.pendingReq != nil {
+			indicator += fmt.Sprintf(" | awaiting: %s %s", m.pendingReq.Method, m.pendingReq.Path)
+		}
+	}
+	status := fmt.Sprintf(" :%d | %d mocks loaded%s | ? help", m.srv.Port, m.srv.MockCount(), indicator)
 	b.WriteString(statusBarStyle.Width(m.width).Render(status))
 
 	return b.String()
@@ -227,6 +291,7 @@ func (m Model) helpView() string {
     esc                 Cancel and go back
 
   General
+    i                   Toggle capture mode
     q / ctrl+c          Quit
 `
 	return titleStyle.Render("Help") + help + "\n\n" + helpStyle.Render("  Press ? to close")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -76,10 +76,13 @@ func (m Model) waitForPending() tea.Cmd {
 	}
 }
 
-// inputActive returns true when a text input has focus and single-char keys
-// (q, ?, n, etc.) should be forwarded to the input instead of treated as commands.
+// inputActive returns true when a text input has focus or a detail overlay is
+// open — single-char keys should not be treated as global commands in either case.
 func (m Model) inputActive() bool {
 	if m.activeTab == tabMockForm && m.mockForm.editing && m.mockForm.focusedField != fieldVerb {
+		return true
+	}
+	if m.activeTab == tabMockList && m.mockList.detailActive() {
 		return true
 	}
 	return false
@@ -335,7 +338,9 @@ func (m Model) helpView() string {
   Mocks Tab
     n                   Create new mock
     e                   Edit selected mock
-    d                   Delete selected mock
+    d                   Show mock details
+    space               Enable/disable mock
+    x                   Delete selected mock
     r                   Reload mocks from disk
 
   Request Log Tab

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -14,11 +14,11 @@ import (
 const (
 	tabMockList = iota
 	tabRequestLog
-	tabMockForm
-	tabCount
+	tabCount    // number of tabs in the tab bar
+	tabMockForm // not in the tab bar; shown as overlay when creating/editing
 )
 
-var tabNames = []string{"Mocks", "Request Log", "Create/Edit"}
+var tabNames = []string{"Mocks", "Request Log"}
 
 type pendingRequestMsg server.PendingRequest
 
@@ -28,29 +28,42 @@ type Model struct {
 	width     int
 	height    int
 
-	mockList mockListModel
-	reqLog   requestLogModel
-	mockForm mockFormModel
+	mockList   mockListModel
+	reqLog     requestLogModel
+	mockForm   mockFormModel
+	mockPicker mockPickerModel
 
-	showHelp      bool
+	showHelp    bool
 	captureMode bool
-	pendingReq    *server.PendingRequest
+	pendingReq  *server.PendingRequest
 }
 
 func NewModel(srv *server.Server) Model {
 	return Model{
-		srv:       srv,
-		activeTab: tabMockList,
-		mockList:  newMockListModel(srv),
-		reqLog:    newRequestLogModel(srv),
-		mockForm:  newMockFormModel(srv),
+		srv:        srv,
+		activeTab:  tabMockList,
+		mockList:   newMockListModel(srv),
+		reqLog:     newRequestLogModel(srv),
+		mockForm:   newMockFormModel(srv),
+		mockPicker: newMockPickerModel(),
 	}
 }
 
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.reqLog.waitForEntry(),
+		m.waitForSelection(),
 	)
+}
+
+func (m Model) waitForSelection() tea.Cmd {
+	return func() tea.Msg {
+		req, ok := <-m.srv.SelectionCh
+		if !ok {
+			return nil
+		}
+		return selectionRequestMsg(req)
+	}
 }
 
 func (m Model) waitForPending() tea.Cmd {
@@ -75,6 +88,27 @@ func (m Model) inputActive() bool {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
+	// When mock picker is active, delegate everything to it except
+	// selectionDoneMsg which is handled below (arrives after active=false).
+	if m.mockPicker.active {
+		switch msg := msg.(type) {
+		case tea.WindowSizeMsg:
+			m.width = msg.Width
+			m.height = msg.Height
+			m.mockPicker.width = msg.Width
+			m.mockPicker.height = msg.Height - 4
+			return m, nil
+		case newLogEntryMsg:
+			var cmd tea.Cmd
+			m.reqLog, cmd = m.reqLog.Update(msg)
+			return m, cmd
+		default:
+			var cmd tea.Cmd
+			m.mockPicker, cmd = m.mockPicker.Update(msg)
+			return m, cmd
+		}
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -85,6 +119,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.reqLog.height = msg.Height - 4
 		m.mockForm.width = msg.Width
 		return m, nil
+
+	case selectionRequestMsg:
+		req := server.SelectionRequest(msg)
+		m.mockPicker.activate(req, m.width, m.height-4)
+		return m, nil
+
+	case selectionDoneMsg:
+		// Re-arm the selection listener. This always arrives after mockPicker.active
+		// has already been set to false, so it must be handled here, not in the
+		// picker-active block above.
+		return m, m.waitForSelection()
 
 	case tea.KeyMsg:
 		// Esc always goes back to mock list from form tabs
@@ -222,6 +267,18 @@ func (m Model) View() string {
 		return m.helpView()
 	}
 
+	// Mock picker overlay takes over the full screen
+	if m.mockPicker.active {
+		var b strings.Builder
+		b.WriteString(m.tabBar())
+		b.WriteString("\n\n")
+		b.WriteString(m.mockPicker.View())
+		b.WriteString("\n")
+		status := fmt.Sprintf(" :%d | %d mocks loaded | SELECTING MOCK | ? help", m.srv.Port, m.srv.MockCount())
+		b.WriteString(statusBarStyle.Width(m.width).Render(status))
+		return b.String()
+	}
+
 	var b strings.Builder
 
 	// Tab bar
@@ -284,11 +341,18 @@ func (m Model) helpView() string {
   Request Log Tab
     c                   Clear log
 
-  Create/Edit Tab
+  Create/Edit Form (opens over Mocks tab)
     ↑/↓                 Cycle between fields
     ←/→                 Cycle HTTP verb (when on Method)
     ctrl+s              Save mock
     esc                 Cancel and go back
+
+  Mock Selection
+    When multiple mocks match the same path+verb,
+    an interactive picker appears on each request.
+    ↑/↓                 Navigate options
+    enter                Select mock
+    esc                  Cancel (returns 404)
 
   General
     i                   Toggle capture mode


### PR DESCRIPTION
## Summary

- Adds **capture mode** (`i` key toggle) that intercepts unmatched HTTP requests and prompts the user to define mock responses via the TUI
- The HTTP handler blocks until the user saves a response, which is sent back to the caller and persisted as a mock JSON file
- Uses a channel-based synchronization pattern between HTTP handler goroutines and the bubbletea TUI, with a queue for concurrent unmatched requests
- Includes ADR documenting the design decision (`docs/adr/001-capture-mode.md`)

## Test plan

- [ ] `go build -v ./...` compiles without errors
- [ ] Run server: `go run cmd/api/main.go -d /tmp/mocks -p 8081`
- [ ] Press `i` — status bar shows **CAPTURE** indicator
- [ ] `curl http://localhost:8081/api/test` — TUI shows pre-filled form with GET /api/test
- [ ] Fill in status/headers/body, press `ctrl+s` — curl receives the response, mock saved to disk
- [ ] Repeat same curl — matches saved mock, no prompt
- [ ] Press `esc` on form — pending request gets 404, no mock created
- [ ] Press `i` again to disable — unmatched requests return 404 normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)