### PR TITLE
Improve request log: body inspection, clipboard copy, always log body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,6 @@ go build -v ./...
 # Run tests
 go test -v ./...
 
-# Run a single test
-go test -v ./internal/router/...
-
 # Run the server with TUI (default)
 go run cmd/api/main.go -d /path/to/mocks -p 8081
 
@@ -29,37 +26,39 @@ go run cmd/api/main.go -d /path/to/mocks -p 8081 --no-tui
 
 `cmd/api/main.go` parses flags (`-p` port, `-d` directory, `--no-tui`) and runs in one of two modes:
 - **TUI mode** (default): creates a `server.Server`, starts HTTP in a goroutine, runs bubbletea on the main goroutine. The TUI and HTTP server share state through the `Server` struct.
-- **Headless mode** (`--no-tui`): loads mocks once, registers routes on a `DynamicMux`, serves HTTP directly. Requests log to stdout via the standard logger.
+- **Headless mode** (`--no-tui`): loads mocks once, registers routes on a `DynamicMux`, serves HTTP directly. Requests log to stdout via the standard logger. No selector or capture — first matching mock is used.
 
 ### Core packages
 
 - `internal/utils/` — resolves mock directory: `-d` flag takes precedence over `SIMPLE_MOCKS_LOCATION` env var.
-- `internal/mock/` — `Mock` struct + `LoadMocksFromFS(dir)` reads all `.json` files. `SaveMockToFS(dir, mock)` writes a mock back to disk (used by the TUI create/edit form). Each mock tracks its `SourceFile`.
-- `internal/router/` — `DynamicMux` is a `sync.RWMutex`-protected handler map that supports runtime route add/remove/clear. `RegisterMocks(mux, mocks, logger)` registers one handler per path per mock. The `RequestLogger` interface decouples request logging from the router (nil falls back to `log.Printf`).
-- `internal/server/` — `Server` struct owns mocks (behind `sync.RWMutex`), the `DynamicMux`, the `http.Server`, and the `RequestLog`. Methods: `LoadAndRegister`, `Start`, `Stop`, `AddMock`, `UpdateMock`, `DeleteMock`, `ReloadMocks`, `Mocks`, `MockCount`. `RequestLog` is a ring buffer (capacity 1000) with channel-based pub/sub for the TUI. Non-blocking sends prevent slow TUI from blocking HTTP handlers.
+- `internal/mock/` — `Mock` struct + `LoadMocksFromFS(dir)` reads all `.json` files. `SaveMockToFS(dir, mock)` writes a mock back to disk, generating a unique filename if the base name already exists (`GET_api_users.json` → `GET_api_users_2.json`). Each mock tracks its `SourceFile`.
+- `internal/router/` — `DynamicMux` is a `sync.RWMutex`-protected handler map. `RegisterMocks(mux, mocks, RouteConfig)` groups mocks by path; each handler filters by verb, then: if multiple matches or capture mode is on it calls `RouteConfig.Selector`; selector returning `-2` calls `RouteConfig.Fallback` (capture flow); disabled mocks are skipped entirely. `RouteConfig.CaptureCheck` lets the server signal whether capture mode is active.
+- `internal/server/` — `Server` owns mocks (behind `sync.RWMutex`), the `DynamicMux`, the `http.Server`, `RequestLog`, `PendingCh`, and `SelectionCh`. Key methods: `LoadAndRegister`, `Start`, `Stop`, `AddMock`, `UpdateMock`, `DeleteMock`, `ToggleMock`, `ReloadMocks`. `handleCapture` is a reusable method that blocks the HTTP handler until the TUI responds via `PendingCh`. `selectMock` is the `MockSelector` — it sends a `SelectionRequest` (with `CaptureMode` flag) to `SelectionCh` and blocks for the response. `RequestLog` is a ring buffer (capacity 1000) with channel-based pub/sub.
 
 ### TUI package (`internal/tui/`)
 
-Built with **bubbletea** (Elm architecture), **bubbles** (text inputs, textareas), and **lipgloss** (styling).
+Built with **bubbletea** (Elm architecture), **bubbles** (text inputs, textareas), and **lipgloss** (styling). Color palette is Dracula-inspired (hex colors).
 
-**Structure:**
-- `tui.go` — top-level `Model` with tab management (Mocks, Request Log, Create/Edit). Handles global keybindings, delegates to sub-models per tab. `newLogEntryMsg` is handled at the top level so log entries are captured regardless of active tab.
-- `keys.go` — all keybinding definitions. Single-char keys (`q`, `?`, `n`, `e`, `d`, `r`, `c`) only work when no text input is focused (`inputActive()` check). `j`/`k` were removed from Up/Down to avoid conflicts with text input.
-- `styles.go` — lipgloss style constants, including per-HTTP-method color coding.
-- `mocklist.go` — table view of loaded mocks with cursor navigation.
-- `mockform.go` — create/edit form with verb selector (left/right arrows), text inputs for paths/status/delay, textareas for headers and JSON body. New mocks default to `Content-Type: application/json` header. Uses `↑`/`↓` to cycle fields. `esc` cancels and returns to Mocks tab.
-- `requestlog.go` — live scrollable request log. Subscribes to `server.RequestLog` channel via `waitForEntry()` tea.Cmd pattern.
+**Files:**
+- `tui.go` — top-level `Model` with two navigable tabs (Mocks, Request Log). The Create/Edit form and mock picker are overlays, not tabs — they are activated by setting `activeTab = tabMockForm` or `mockPicker.active = true`. Handles global keybindings and all inter-component message routing.
+- `keys.go` — all keybinding definitions. `inputActive()` gates single-char keys; it now also returns true when the mock list detail overlay is open.
+- `styles.go` — lipgloss style constants. `methodStyle(verb)` returns per-HTTP-method colors. `statusStyle(code)` returns color by HTTP status class (2xx green, 3xx yellow, 4xx orange, 5xx red). **Critical:** always pad columns with plain strings (`fmt.Sprintf("%-Ns", plain)`) *before* applying lipgloss styles, then concatenate. Never pass already-styled strings into `fmt.Sprintf` format directives — ANSI escape codes inflate byte counts and break column alignment.
+- `mocklist.go` — table view of loaded mocks. `d` opens a detail overlay (method, paths, status, delay, file, headers, body). `space` toggles mock enabled/disabled. `x` deletes. Detail overlay blocks global keys via `inputActive()`.
+- `mockform.go` — create/edit form. Opens as an overlay over the Mocks tab (not a separate tab). `esc` always returns to Mocks tab.
+- `mockpicker.go` — interactive overlay shown when multiple mocks match a request, or when capture mode is on and an existing route is hit. Shows existing mocks + optional "+ Define new mock" row (when `CaptureMode` is true). Returns `-2` for "define new" which triggers the capture flow. **Important:** `selectionDoneMsg` always arrives *after* `mockPicker.active` has been set to false, so it must be handled in the main switch of `tui.go`, not inside the picker-active block.
+- `requestlog.go` — live request log with cursor navigation. `enter` opens a detail overlay with full request body (pretty-printed if JSON). `y` copies the body to clipboard via `atotto/clipboard`. Request bodies are always logged (no opt-in flag).
 
 **Concurrency model:**
 - Main goroutine → bubbletea (owns stdin/stdout)
 - Background goroutine → `http.Server.ListenAndServe()`
-- Per-request goroutine → handler writes to `RequestLog` channel
-- bubbletea cmd → reads from channel, dispatches `newLogEntryMsg`
+- Per-request goroutine → handler may block on `SelectionCh` (mock picker) or `PendingCh` (capture form), then writes to `RequestLog`
+- bubbletea cmds → `waitForEntry()`, `waitForPending()`, `waitForSelection()` each block on their respective channel and return a message when data arrives. They must be re-dispatched after each message is consumed.
 
 **Key TUI design decisions:**
-- Tab switching (`tab`/`shift+tab`) puts tabs in "browse mode" — text inputs are blurred. Press `Enter` to engage form inputs. This prevents getting stuck in a tab.
-- `inputActive()` gates whether single-char keys are treated as commands or forwarded to text inputs.
-- `esc` from Create/Edit always returns to Mocks tab regardless of form state.
+- `waitForSelection()` is re-dispatched from `selectionDoneMsg` in the main switch (not the picker-active block) because bubbletea updates model state before delivering the cmd's message.
+- `waitForPending()` is started when capture mode is toggled on and re-dispatched from `mockSavedMsg`. No extra dispatch needed from `selectionDoneMsg`.
+- Column alignment: pad with plain strings first, then style, then concatenate — never use `fmt.Sprintf("%-Ns", styledString)`.
+- Tab switching blurs all inputs ("browse mode"). Press `Enter` to engage form inputs.
 
 ### Mock JSON format
 
@@ -70,15 +69,16 @@ Built with **bubbletea** (Elm architecture), **bubbles** (text inputs, textareas
     "body": { "key": "value" },
     "headers": { "Content-Type": "application/json" },
     "status": 200,
-    "print_request_body": true,
-    "response_time": 100
+    "response_time": 100,
+    "disabled": false
 }
 ```
 
-`print_request_body: true` logs the incoming request body. `response_time` is a delay in milliseconds before responding.
+`response_time` is a delay in milliseconds. `disabled: true` skips the mock during route registration without deleting it. Request bodies are always captured. `print_request_body` no longer exists.
 
 ### Dependencies
 
 - `github.com/charmbracelet/bubbletea` — TUI framework (Elm architecture)
 - `github.com/charmbracelet/bubbles` — TUI components (textinput, textarea)
 - `github.com/charmbracelet/lipgloss` — terminal styling/layout
+- `github.com/atotto/clipboard` — clipboard access for copying request bodies

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Each `.json` file in the mocks directory defines one mock:
         "users": [{ "id": 1, "name": "alice" }]
     },
     "response_time": 150,
-    "print_request_body": false,
     "disabled": false
 }
 ```
@@ -86,7 +85,6 @@ Each `.json` file in the mocks directory defines one mock:
 | `headers` | `object` | Response headers |
 | `body` | `any` | JSON response body |
 | `response_time` | `int` | Delay in milliseconds before responding |
-| `print_request_body` | `bool` | Print the incoming request body to the log |
 | `disabled` | `bool` | When `true`, the mock is loaded but not served (omit to default to enabled) |
 
 > Multiple JSON files can define mocks for the same path + verb. The TUI will ask you to pick one on each request.

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -15,7 +15,6 @@ type Mock struct {
 	Body             any               `json:"body"`
 	Headers          map[string]string `json:"headers"`
 	Status           int               `json:"status"`
-	PrintRequestBody bool              `json:"print_request_body"`
 	ResponseTime     int               `json:"response_time"`
 	Disabled         bool              `json:"disabled,omitempty"`
 	SourceFile       string            `json:"-"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -39,6 +39,24 @@ type RouteConfig struct {
 	Fallback     http.HandlerFunc // called when selector returns -2 (define new)
 }
 
+// writeErrorJSON writes a JSON error response and optionally logs it.
+func writeErrorJSON(w http.ResponseWriter, r *http.Request, status int, message string, logger RequestLogger) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":  message,
+		"method": r.Method,
+		"path":   r.URL.Path,
+	})
+	if logger != nil {
+		logger.Log(RequestEntry{
+			Method: r.Method,
+			Path:   r.RequestURI,
+			Status: status,
+		})
+	}
+}
+
 func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, cfg RouteConfig) {
 	// Group mocks by path
 	grouped := make(map[string][]mock.Mock)
@@ -72,7 +90,7 @@ func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, cfg RouteConfig) {
 					cfg.Fallback(w, r)
 					return
 				}
-				w.WriteHeader(http.StatusMethodNotAllowed)
+				writeErrorJSON(w, r, http.StatusMethodNotAllowed, "method not allowed for this route", cfg.Logger)
 				return
 			}
 
@@ -90,7 +108,7 @@ func RegisterMocks(mux *DynamicMux, mocks []mock.Mock, cfg RouteConfig) {
 					cfg.Fallback(w, r)
 					return
 				case idx < 0 || idx >= len(matches):
-					http.NotFound(w, r)
+					writeErrorJSON(w, r, http.StatusNotFound, "no mock selected", cfg.Logger)
 					return
 				default:
 					serveMock(w, r, matches[idx], cfg.Logger)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -115,10 +115,8 @@ func serveMock(w http.ResponseWriter, r *http.Request, m mock.Mock, logger Reque
 	json.NewEncoder(w).Encode(m.Body)
 
 	var bodyStr string
-	if m.PrintRequestBody {
-		if b, err := io.ReadAll(r.Body); err == nil {
-			bodyStr = string(b)
-		}
+	if b, err := io.ReadAll(r.Body); err == nil {
+		bodyStr = string(b)
 	}
 
 	entry := RequestEntry{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -105,7 +106,18 @@ func New(port int, mocksDir string) *Server {
 
 	mux.NotFoundHandler = func(w http.ResponseWriter, r *http.Request) {
 		if !s.CaptureMode() {
-			http.NotFound(w, r)
+			s.ReqLog.Log(router.RequestEntry{
+				Method: r.Method,
+				Path:   r.RequestURI,
+				Status: http.StatusNotFound,
+			})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error":  "no mock defined for this route",
+				"method": r.Method,
+				"path":   r.URL.Path,
+			})
 			return
 		}
 		s.handleCapture(w, r)

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -20,6 +20,7 @@ type keyMap struct {
 	Down     key.Binding
 	Capture  key.Binding
 	Toggle   key.Binding
+	Copy     key.Binding
 }
 
 var keys = keyMap{
@@ -90,5 +91,9 @@ var keys = keyMap{
 	Toggle: key.NewBinding(
 		key.WithKeys(" "),
 		key.WithHelp("space", "enable/disable mock"),
+	),
+	Copy: key.NewBinding(
+		key.WithKeys("y"),
+		key.WithHelp("y", "copy body"),
 	),
 }

--- a/internal/tui/mocklist.go
+++ b/internal/tui/mocklist.go
@@ -93,7 +93,8 @@ func (m mockListModel) View() string {
 func (m mockListModel) listView() string {
 	var b strings.Builder
 
-	header := fmt.Sprintf("  %-3s %-8s %-40s %-8s %s", "", "METHOD", "PATHS", "STATUS", "DELAY(ms)")
+	// Mirror the data row layout exactly: "  "(cursor) + dot(1) + " " + verb(8) + " " + paths(40) + ...
+	header := "  " + " " + " " + fmt.Sprintf("%-8s", "METHOD") + " " + fmt.Sprintf("%-40s", "PATHS") + " " + fmt.Sprintf("%-8s", "STATUS") + " " + "DELAY(ms)"
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8F8F2")).Render(header))
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", min(m.width, 80)))

--- a/internal/tui/requestlog.go
+++ b/internal/tui/requestlog.go
@@ -1,22 +1,28 @@
 package tui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"simple-mock-server/internal/server"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 type requestLogModel struct {
-	srv     *server.Server
-	entries []server.LogEntry
-	sub     chan server.LogEntry
-	scroll  int
-	width   int
-	height  int
+	srv        *server.Server
+	entries    []server.LogEntry
+	sub        chan server.LogEntry
+	cursor     int
+	scroll     int
+	width      int
+	height     int
+	showDetail bool
+	copyMsg    string // transient feedback after copying
 }
 
 func newRequestLogModel(srv *server.Server) requestLogModel {
@@ -43,44 +49,93 @@ func (m requestLogModel) Update(msg tea.Msg) (requestLogModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case newLogEntryMsg:
 		m.entries = append(m.entries, server.LogEntry(msg))
-		// Auto-scroll to bottom
-		maxVisible := m.height - 4
+		// Follow new entries only when already at the bottom
+		maxVisible := m.height - 6
 		if maxVisible < 1 {
 			maxVisible = 10
 		}
-		if len(m.entries) > maxVisible {
-			m.scroll = len(m.entries) - maxVisible
+		atBottom := m.cursor == len(m.entries)-2 // cursor was on last entry
+		m.cursor = len(m.entries) - 1
+		if atBottom || len(m.entries) == 1 {
+			if len(m.entries) > maxVisible {
+				m.scroll = len(m.entries) - maxVisible
+			}
 		}
 		return m, m.waitForEntry()
 
 	case tea.KeyMsg:
+		if m.showDetail {
+			switch {
+			case key.Matches(msg, keys.Back):
+				m.showDetail = false
+				m.copyMsg = ""
+			case key.Matches(msg, keys.Copy):
+				if m.cursor >= 0 && m.cursor < len(m.entries) {
+					body := m.entries[m.cursor].RequestBody
+					if body == "" {
+						m.copyMsg = "nothing to copy — no request body was logged"
+					} else if err := clipboard.WriteAll(body); err != nil {
+						m.copyMsg = "copy failed: " + err.Error()
+					} else {
+						m.copyMsg = "copied to clipboard!"
+					}
+				}
+			}
+			return m, nil
+		}
+
 		switch {
 		case key.Matches(msg, keys.Clear):
 			m.srv.ReqLog.Clear()
 			m.entries = nil
+			m.cursor = 0
 			m.scroll = 0
 		case key.Matches(msg, keys.Up):
-			if m.scroll > 0 {
-				m.scroll--
+			if m.cursor > 0 {
+				m.cursor--
+				m.clampScroll()
 			}
 		case key.Matches(msg, keys.Down):
-			maxVisible := m.height - 4
-			if maxVisible < 1 {
-				maxVisible = 10
+			if m.cursor < len(m.entries)-1 {
+				m.cursor++
+				m.clampScroll()
 			}
-			if m.scroll < len(m.entries)-maxVisible {
-				m.scroll++
+		case msg.String() == "enter":
+			if len(m.entries) > 0 {
+				m.showDetail = true
+				m.copyMsg = ""
 			}
 		}
 	}
 	return m, nil
 }
 
+// clampScroll keeps the cursor visible in the viewport.
+func (m *requestLogModel) clampScroll() {
+	maxVisible := m.height - 6
+	if maxVisible < 1 {
+		maxVisible = 10
+	}
+	if m.cursor < m.scroll {
+		m.scroll = m.cursor
+	}
+	if m.cursor >= m.scroll+maxVisible {
+		m.scroll = m.cursor - maxVisible + 1
+	}
+}
+
 func (m requestLogModel) View() string {
+	if m.showDetail && len(m.entries) > 0 {
+		return m.detailView(m.entries[m.cursor])
+	}
+	return m.listView()
+}
+
+func (m requestLogModel) listView() string {
 	var b strings.Builder
 
-	header := fmt.Sprintf("  %-12s %-8s %-35s %-8s %-10s", "TIME", "METHOD", "PATH", "STATUS", "DELAY(ms)")
-	b.WriteString(helpStyle.Render(header))
+	header := fmt.Sprintf("  %-3s %-12s %-8s %-35s %-8s %-10s", "", "TIME", "METHOD", "PATH", "STATUS", "DELAY(ms)")
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8F8F2")).Render(header))
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", min(m.width, 90)))
 	b.WriteString("\n")
@@ -101,18 +156,35 @@ func (m requestLogModel) View() string {
 
 	for i := m.scroll; i < end; i++ {
 		e := m.entries[i]
-		ts := e.Timestamp.Format("15:04:05.000")
-		verb := methodStyle(e.Method).Render(fmt.Sprintf("%-8s", e.Method))
-		line := fmt.Sprintf("  %-12s %s %-35s %-8d %-10d", ts, verb, e.Path, e.Status, e.ResponseTime)
-		b.WriteString(line)
-		if e.RequestBody != "" {
-			b.WriteString("\n    Body: " + truncate(e.RequestBody, 60))
+		cur := "  "
+		if i == m.cursor {
+			cur = "▸ "
 		}
+
+		ts := e.Timestamp.Format("15:04:05.000")
+		verbPadded := fmt.Sprintf("%-8s", e.Method)
+		verb := methodStyle(e.Method).Render(verbPadded)
+		pathPadded := fmt.Sprintf("%-35s", truncate(e.Path, 35))
+		statusPadded := fmt.Sprintf("%-8d", e.Status)
+		status := statusStyle(e.Status).Render(statusPadded)
+		delayPadded := fmt.Sprintf("%-10d", e.ResponseTime)
+
+		line := fmt.Sprintf("  %s%-12s ", cur, ts) + verb + " " + pathPadded + " " + status + " " + delayPadded
+
+		if e.RequestBody != "" {
+			line += lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Render(" ⬡ body")
+		}
+
+		if i == m.cursor {
+			line = lipgloss.NewStyle().Background(lipgloss.Color("#44475A")).Render(line)
+		}
+
+		b.WriteString(line)
 		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render(fmt.Sprintf("  %d requests | c: clear  ↑/↓: scroll", len(m.entries))))
+	b.WriteString(helpStyle.Render(fmt.Sprintf("  %d requests | enter: inspect  c: clear  ↑/↓: navigate", len(m.entries))))
 
 	return b.String()
 }
@@ -122,4 +194,63 @@ func truncate(s string, max int) string {
 		return s
 	}
 	return s[:max-3] + "..."
+}
+
+func (m requestLogModel) detailView(e server.LogEntry) string {
+	var b strings.Builder
+
+	banner := fmt.Sprintf("REQUEST DETAIL: %s %s", e.Method, e.Path)
+	b.WriteString(liveRequestBannerStyle.Render(banner))
+	b.WriteString("\n\n")
+
+	row := func(label, value string) string {
+		l := lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Bold(true).Render(fmt.Sprintf("  %-14s", label))
+		return l + " " + value
+	}
+
+	b.WriteString(row("Time", lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(e.Timestamp.Format("2006-01-02 15:04:05.000"))))
+	b.WriteString("\n")
+	b.WriteString(row("Method", methodStyle(e.Method).Render(e.Method)))
+	b.WriteString("\n")
+	b.WriteString(row("Path", lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(e.Path)))
+	b.WriteString("\n")
+	b.WriteString(row("Status", statusStyle(e.Status).Render(fmt.Sprintf("%d", e.Status))))
+	b.WriteString("\n")
+	b.WriteString(row("Delay", lipgloss.NewStyle().Foreground(lipgloss.Color("#F8F8F2")).Render(fmt.Sprintf("%d ms", e.ResponseTime))))
+	b.WriteString("\n")
+
+	b.WriteString("\n")
+	bodyLabel := lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Bold(true).Render("  Request Body")
+	b.WriteString(bodyLabel)
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("─", min(m.width, 60)))
+	b.WriteString("\n")
+
+	if e.RequestBody == "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4")).Italic(true).Render("  (no body)"))
+	} else {
+		body := e.RequestBody
+		// Pretty-print if valid JSON
+		var js any
+		if err := json.Unmarshal([]byte(body), &js); err == nil {
+			if pretty, err := json.MarshalIndent(js, "  ", "  "); err == nil {
+				body = string(pretty)
+			}
+		}
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Render("  " + strings.ReplaceAll(body, "\n", "\n  ")))
+	}
+
+	b.WriteString("\n\n")
+
+	hint := "  esc: back"
+	if e.RequestBody != "" {
+		if m.copyMsg != "" {
+			hint += "  |  " + lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Bold(true).Render(m.copyMsg)
+		} else {
+			hint += "  |  " + helpStyle.Render("y: copy body to clipboard")
+		}
+	}
+	b.WriteString(helpStyle.Render(hint))
+
+	return b.String()
 }

--- a/internal/tui/requestlog.go
+++ b/internal/tui/requestlog.go
@@ -45,22 +45,19 @@ func (m requestLogModel) waitForEntry() tea.Cmd {
 	}
 }
 
+// entryAt returns the entry for visual index i (0 = newest).
+func (m requestLogModel) entryAt(i int) server.LogEntry {
+	return m.entries[len(m.entries)-1-i]
+}
+
 func (m requestLogModel) Update(msg tea.Msg) (requestLogModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case newLogEntryMsg:
 		m.entries = append(m.entries, server.LogEntry(msg))
-		// Follow new entries only when already at the bottom
-		maxVisible := m.height - 6
-		if maxVisible < 1 {
-			maxVisible = 10
-		}
-		atBottom := m.cursor == len(m.entries)-2 // cursor was on last entry
-		m.cursor = len(m.entries) - 1
-		if atBottom || len(m.entries) == 1 {
-			if len(m.entries) > maxVisible {
-				m.scroll = len(m.entries) - maxVisible
-			}
-		}
+		// New entries appear at the top; keep cursor at 0 so the user
+		// always sees the latest request without manual scrolling.
+		m.cursor = 0
+		m.scroll = 0
 		return m, m.waitForEntry()
 
 	case tea.KeyMsg:
@@ -70,8 +67,8 @@ func (m requestLogModel) Update(msg tea.Msg) (requestLogModel, tea.Cmd) {
 				m.showDetail = false
 				m.copyMsg = ""
 			case key.Matches(msg, keys.Copy):
-				if m.cursor >= 0 && m.cursor < len(m.entries) {
-					body := m.entries[m.cursor].RequestBody
+				if len(m.entries) > 0 {
+					body := m.entryAt(m.cursor).RequestBody
 					if body == "" {
 						m.copyMsg = "nothing to copy — no request body was logged"
 					} else if err := clipboard.WriteAll(body); err != nil {
@@ -126,7 +123,7 @@ func (m *requestLogModel) clampScroll() {
 
 func (m requestLogModel) View() string {
 	if m.showDetail && len(m.entries) > 0 {
-		return m.detailView(m.entries[m.cursor])
+		return m.detailView(m.entryAt(m.cursor))
 	}
 	return m.listView()
 }
@@ -134,7 +131,8 @@ func (m requestLogModel) View() string {
 func (m requestLogModel) listView() string {
 	var b strings.Builder
 
-	header := fmt.Sprintf("  %-3s %-12s %-8s %-35s %-8s %-10s", "", "TIME", "METHOD", "PATH", "STATUS", "DELAY(ms)")
+	// Mirror the data row layout: "  "(2) + cur(2) + ts(12) + " " + verb(8) + ...
+	header := "  " + "  " + fmt.Sprintf("%-12s", "TIME") + " " + fmt.Sprintf("%-8s", "METHOD") + " " + fmt.Sprintf("%-35s", "PATH") + " " + fmt.Sprintf("%-8s", "STATUS") + " " + "DELAY(ms)"
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8F8F2")).Render(header))
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", min(m.width, 90)))
@@ -155,7 +153,7 @@ func (m requestLogModel) listView() string {
 	}
 
 	for i := m.scroll; i < end; i++ {
-		e := m.entries[i]
+		e := m.entryAt(i)
 		cur := "  "
 		if i == m.cursor {
 			cur = "▸ "

--- a/internal/tui/requestlog.go
+++ b/internal/tui/requestlog.go
@@ -233,11 +233,17 @@ func (m requestLogModel) detailView(e server.LogEntry) string {
 		// Pretty-print if valid JSON
 		var js any
 		if err := json.Unmarshal([]byte(body), &js); err == nil {
-			if pretty, err := json.MarshalIndent(js, "  ", "  "); err == nil {
+			if pretty, err := json.MarshalIndent(js, "", "  "); err == nil {
 				body = string(pretty)
 			}
 		}
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Render("  " + strings.ReplaceAll(body, "\n", "\n  ")))
+		// Render each line individually — lipgloss misaligns multiline strings
+		// when passed as a single Render call.
+		lineStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B"))
+		for _, line := range strings.Split(body, "\n") {
+			b.WriteString(lineStyle.Render("  " + line))
+			b.WriteString("\n")
+		}
 	}
 
 	b.WriteString("\n\n")


### PR DESCRIPTION
## Summary

- **Always log request body** — removed the `print_request_body` opt-in flag; every request body is now captured automatically
- **Request log cursor + detail view** — `↑/↓` navigates entries, `enter` opens a detail overlay showing the full request body (pretty-printed if JSON), timestamp, method, path, status and delay
- **Copy to clipboard** — press `y` in the detail view to copy the request body to the clipboard; shows inline feedback
- **CLAUDE.md updated** — documents all features added across recent sessions (multi-mock routing, capture-on-existing-route, enable/disable, mock picker concurrency, column alignment rule)

## Test plan

- [ ] Send requests with a JSON body and verify it appears in the log
- [ ] Press `enter` on a log entry and confirm detail view opens with pretty-printed body
- [ ] Press `y` in detail view and paste to confirm clipboard contents
- [ ] Press `esc` to close detail and return to log
- [ ] Confirm existing mock JSON files with `print_request_body` field still load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)