### PR TITLE
Fix TUI log pollution on reload and stale mock count on toggle

### DIFF
--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -29,8 +29,6 @@ func LoadMocksFromFS(directory string) ([]Mock, error) {
 	for _, file := range files {
 		if filepath.Ext(file.Name()) == ".json" {
 			filePath := filepath.Join(directory, file.Name())
-			log.Printf("Using %s\n", filePath)
-
 			content, err := os.ReadFile(filePath)
 			if err != nil {
 				log.Printf("Error reading file %s: %s\n", filePath, err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -236,6 +236,18 @@ func (s *Server) ReloadMocks() error {
 func (s *Server) MockCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	n := 0
+	for _, m := range s.mocks {
+		if !m.Disabled {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *Server) TotalMockCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return len(s.mocks)
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -277,7 +277,7 @@ func (m Model) View() string {
 		b.WriteString("\n\n")
 		b.WriteString(m.mockPicker.View())
 		b.WriteString("\n")
-		status := fmt.Sprintf(" :%d | %d mocks loaded | SELECTING MOCK | ? help", m.srv.Port, m.srv.MockCount())
+		status := fmt.Sprintf(" :%d | %d/%d mocks active | SELECTING MOCK | ? help", m.srv.Port, m.srv.MockCount(), m.srv.TotalMockCount())
 		b.WriteString(statusBarStyle.Width(m.width).Render(status))
 		return b.String()
 	}
@@ -307,7 +307,7 @@ func (m Model) View() string {
 			indicator += fmt.Sprintf(" | awaiting: %s %s", m.pendingReq.Method, m.pendingReq.Path)
 		}
 	}
-	status := fmt.Sprintf(" :%d | %d mocks loaded%s | ? help", m.srv.Port, m.srv.MockCount(), indicator)
+	status := fmt.Sprintf(" :%d | %d/%d mocks active%s | ? help", m.srv.Port, m.srv.MockCount(), m.srv.TotalMockCount(), indicator)
 	b.WriteString(statusBarStyle.Width(m.width).Render(status))
 
 	return b.String()


### PR DESCRIPTION
## Summary

- Remove `log.Printf` from `LoadMocksFromFS` that was writing file paths to stderr on every reload (`r`), corrupting the TUI alt-screen rendering
- `MockCount()` now counts only enabled mocks; added `TotalMockCount()` for the total
- Status bar shows `N/M mocks active` so toggling a mock disabled is immediately visible

## Test plan

- [ ] Press `r` to reload mocks — no log output should appear in the terminal
- [ ] Toggle a mock disabled with `space` — status bar count should decrease
- [ ] Re-enable the mock — count should go back up
- [ ] Verify `N/M mocks active` format shows correct values in both normal and picker views

🤖 Generated with [Claude Code](https://claude.com/claude-code)